### PR TITLE
DOCS: [개선] 이미지 파일 외 확장자로 업로드 시 업로드 불가 알림 추가

### DIFF
--- a/src/pages/User.jsx
+++ b/src/pages/User.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { IoMdSettings } from 'react-icons/io';
-// import { FaPen } from 'react-icons/fa';
 import { api, userApi } from '../apis/apiInstance';
 import { Link, useNavigate } from 'react-router-dom';
 import axios from 'axios';
@@ -92,13 +91,15 @@ const User = (props) => {
     e.preventDefault();
     const file = e.target.files[0];
 
-    if (file) {
+    if (file.type.includes('image')) {
       const reader = new FileReader();
       reader.readAsDataURL(file);
       reader.onloadend = () => {
         setPrevImg(reader.result);
       };
       setNewImg(file);
+    } else {
+      alert('이미지 파일만 업로드 가능합니다.');
     }
     setIsFileClicked(true);
   };


### PR DESCRIPTION
#31 
input `accept='image/*'` 속성만으로는 이미지 외 확장자 업로드가 제한되지 않아서 관련 코드 추가